### PR TITLE
Adding an option to specify registry_uri for model registry

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -61,9 +61,6 @@ steps:
     # Indicates whether or not a model that fails to meet performance thresholds should still
     # be registered to the MLflow Model Registry
     allow_non_validated_model: true
-    # Set the registry server URI. This property is especially useful if you have a registry
-    # server that’s different from the tracking server.
-    # registry_uri: {{REGISTRY_URI}}
 metrics:
   # Defines custom performance metrics to compute during model training and evaluation
   custom:

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -61,6 +61,9 @@ steps:
     # Indicates whether or not a model that fails to meet performance thresholds should still
     # be registered to the MLflow Model Registry
     allow_non_validated_model: true
+    # Set the registry server URI. This property is especially useful if you have a registry
+    # server that’s different from the tracking server.
+    # registry_uri: {{REGISTRY_URI}}
 metrics:
   # Defines custom performance metrics to compute during model training and evaluation
   custom:

--- a/profiles/databricks.yaml
+++ b/profiles/databricks.yaml
@@ -3,6 +3,12 @@
 # experiment:
   # name: "/Shared/sklearn_regression_experiment"
 
+# Set the registry server URI. This property is especially useful if you have a registry
+# server that’s different from the tracking server.
+# Profile could be created using https://github.com/databricks/databricks-cli#installation
+# model_registry:
+#   uri: "databricks://PROFILE_NAME"
+
 # Use a section of the TLC Trip Record Dataset for model development
 # (https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page)
 INGEST_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
@@ -10,5 +16,3 @@ INGEST_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
 INGEST_DATA_FORMAT: spark_sql
 # Override the default train / validation / test dataset split ratios
 SPLIT_RATIOS: [0.75, 0.125, 0.125]
-# Specify the registry_uri if required
-# REGISTRY_URI: sqlite:////tmp/registry.db

--- a/profiles/databricks.yaml
+++ b/profiles/databricks.yaml
@@ -10,3 +10,5 @@ INGEST_DATA_LOCATION: dbfs:/databricks-datasets/nyctaxi-with-zipcodes/subsampled
 INGEST_DATA_FORMAT: spark_sql
 # Override the default train / validation / test dataset split ratios
 SPLIT_RATIOS: [0.75, 0.125, 0.125]
+# Specify the registry_uri if required
+# REGISTRY_URI: sqlite:////tmp/registry.db

--- a/profiles/local.yaml
+++ b/profiles/local.yaml
@@ -3,6 +3,11 @@ experiment:
   tracking_uri: "sqlite:///metadata/mlflow/mlruns.db"
   artifact_location: "./metadata/mlflow/mlartifacts"
 
+# Set the registry server URI. This property is especially useful if you have a registry
+# server that’s different from the tracking server.
+# model_registry:
+#   uri: sqlite:////tmp/registry.db
+
 # Use a small sample from the TLC Trip Record Dataset for exploring the MLflow Regression Pipeline
 # (https://www1.nyc.gov/site/tlc/about/tlc-trip-record-data.page)
 INGEST_DATA_LOCATION: "./data/sample.parquet"


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding an option to specify registry_uri for model registry

## How is this patch tested?
- [x] Tested with mlflow repo

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [x] `area/regression`: Sklearn regression pipeline example
- [ ] `area/build`: Build and test infrastructure for MLflow pipeline example

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
