### PR TITLE
Add full reference for template to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Note that iteration will likely involve filling in the optional `FIXME`s in the
 step code files with your own code, in addition to the configuration keys.
 
 ## Reference
-TODO INSERT IMAGE
+![image](https://user-images.githubusercontent.com/51172624/195406309-0acf2d6b-19ad-4023-b631-833d4febfc8d.png)
 
 This is a visual overview of the MLflow Regression Pipeline's information flow.
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ It should return a Pandas DataFrame representing the content of the specified fi
 #### Data
 The input dataset is specified by the `data` section in [`pipeline.yaml`](https://github.com/mlflow/mlp-regression-template/blob/main/pipeline.yaml) as follows: 
 <details>
-<summary>Full configuration reference</summary>
+<summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `location`: string. Required, unless `format` is `spark_sql`.  
 Dataset locations on the local filesystem are supported, as 
@@ -167,7 +167,7 @@ It should return a triple representing the processed train, validation and test 
 
 The split step is configured by the `steps.split` section in `pipeline.yaml` as follows:
 <details>
-<summary>Full configuration reference</summary>
+<summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `split_ratios`: list. Optional.  
 A YAML list specifying the ratios by which to split the dataset into training, validation and test sets.  
@@ -202,7 +202,7 @@ and should return an unfitted estimator that is sklearn-compatible; that is, the
 
 The transform step is configured by the `steps.transform` section in pipeline.yaml:
 <details>
-<summary>Full configuration reference</summary>
+<summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `transformer_method`: string. Optional.  
 Fully qualified name of the method that returns an `sklearn`-compatible transformer which applies feature 
@@ -236,7 +236,7 @@ and should return an unfitted estimator that is `sklearn`-compatible; that is, t
 
 The train step is configured by the `steps.train` section in pipeline.yaml:
 <details>
-<summary>Full configuration reference</summary>
+<summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `estimator_method`: string. Required.  
 Fully qualified name of the method that returns an `sklearn`-compatible estimator used for model training.  
@@ -267,7 +267,7 @@ Model performance metrics and explanations are logged to the same MLflow Trackin
 
 The evaluate step is configured by the `steps.evaluate` section in pipeline.yaml:
 <details>
-<summary>Full configuration reference</summary>
+<summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `validation_criteria`: list. Optional.  
 A list of validation thresholds, each of which a trained model must meet in order to be eligible for 
@@ -298,7 +298,7 @@ the model name and the model version.
 
 The register step is configured by the `steps.register` section in pipeline.yaml:
 <details>
-<summary>Full configuration reference</summary>
+<summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `model_name`: string. Required.  
 Specifies the name to use when registering the trained model to the model registry.
@@ -324,7 +324,7 @@ Configuring a tracking server is optional. If this configuration is absent, the 
 
 Tracking information is configured with the `experiment` section in the profile configuration:
 <details>
-<summary>Full configuration reference</summary>
+<summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `name`: string. Required, if configuring tracking.  
 Name of the experiment to log MLflow runs to.
@@ -343,7 +343,7 @@ To register trained models to the MLflow Model Registry, further configuration m
 
 To register models to a different server, specify the desired server in the `model_registry` section in the profile configuration:
 <details>
-<summary>Full configuration reference</summary>
+<summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `uri`: string. Required, if this section is present.  
 URI of the model registry server to which to register trained models.
@@ -363,7 +363,7 @@ Models are ranked by this primary metric.
 
 Metrics are configured under the `metrics` section of pipeline.yaml, according to the following specification:
 <details>
-<summary>Full configuration reference</summary>
+<summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `primary`: string. Required.  
 The name of the primary evaluation metric.
@@ -443,7 +443,7 @@ Once a scoring dataset is ingested, the `predict` step uses the model produced b
 against the scoring dataset.
 The predict step is configured by the `steps.predict` section in pipeline.yaml:
 <details>
-<summary>Full configuration reference</summary>
+<summary><strong><u>Full configuration reference</u></strong></summary>
 
 - `model_uri`: string. Optional.  
 Specifies the URI of the model to use in batch scoring. If empty, the latest model registered from the training step will be used.  

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You may need to install additional libraries for extra features:
 These libraries are available natively in the [Databricks Runtime for Machine Learning](https://docs.databricks.com/runtime/mlruntime.html).
 
 ## Get started
-After installing MLflow Pipelines, you can clone this repository to get started. Simply fill in the required values in the [Pipeline configuration file](https://github.com/mlflow/mlp-regression-template/blob/main/pipeline.yaml) 
+After installing MLflow Pipelines, you can clone this repository to get started. Simply fill in the required values annotated by `FIXME::REQUIRED` comments in the [Pipeline configuration file](https://github.com/mlflow/mlp-regression-template/blob/main/pipeline.yaml) 
 and in the appropriate profile configuration: [`local.yaml`](https://github.com/mlflow/mlp-regression-template/blob/main/profiles/local.yaml) 
 (if running locally) or [`databricks.yaml`](https://github.com/mlflow/mlp-regression-template/blob/main/profiles/databricks.yaml) 
 (if running on Databricks).
@@ -46,7 +46,7 @@ The Pipeline will then be in a runnable state, and when run completely, will pro
 scoring, along with cards containing detailed information about the results of each step. 
 The model will also be registered to the MLflow Model Registry if it meets registration thresholds. 
 To iterate and improve your model, follow the [MLflow Pipelines usage guide](https://mlflow.org/docs/latest/pipelines.html#usage). 
-Note that iteration will likely involve filling in the FIXMEs in the 
+Note that iteration will likely involve filling in the optional `FIXME`s in the 
 step code files with your own code, in addition to the configuration keys.
 
 ## Reference
@@ -78,9 +78,9 @@ A detailed reference for each step follows.
     + [Metrics](#metrics)
       - [Built-in metrics](#built-in-metrics)
       - [Custom metrics](#custom-metrics)
-  * [Scoring](#scoring)
-    + [Ingest step (scoring)](#ingest-step-scoring)
-    + [Predict step](#predict-step)
+    + [Scoring](#scoring)
+      - [Ingest step (scoring)](#ingest-step-scoring)
+      - [Predict step](#predict-step)
 
 ### Step artifacts
 Each of the steps in the pipeline produces artifacts after completion. These artifacts consist of cards containing
@@ -422,10 +422,10 @@ custom:
    greater_is_better: True
 ```
 
-## Scoring
+### Batch scoring
 After model training, the regression pipeline provides a capability for performing model inference against new data.
 
-### Ingest step (scoring)
+#### Ingest step (scoring)
 The dataset to perform inference against is defined in the profile configuration (`profiles/local.yaml` and `profiles/databricks.yaml`)
 according to the following specification:
 - `INGEST_SCORING_DATA_LOCATION`: string. Required for inference.  
@@ -438,7 +438,7 @@ One of `parquet`, `spark_sql` and `delta`.
 **Step artifacts**:
 - `ingested_scoring_data`: the scoring dataset as a Pandas DataFrame
 
-### Predict step
+#### Predict step
 Once a scoring dataset is ingested, the `predict` step uses the model produced by the regression pipeline to predict 
 against the scoring dataset.
 The predict step is configured by the `steps.predict` section in pipeline.yaml:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ It is designed for developing models using scikit-learn and frameworks that inte
 such as the `XGBRegressor` API from XGBoost.
 
 This repository is a template for developing production-ready regression models with the MLflow Regression Pipeline.
-It provides a pipeline structure for creating models, and pointers to configurations and code files that should
+It provides a pipeline structure for creating models as well as pointers to configurations and code files that should
 be filled in to produce a working pipeline.
 
 Code developed with this template should be run with [MLflow Pipelines](https://mlflow.org/docs/latest/pipelines.html). 
@@ -37,11 +37,11 @@ You may need to install additional libraries for extra features:
 These libraries are available natively in the [Databricks Runtime for Machine Learning](https://docs.databricks.com/runtime/mlruntime.html).
 
 ## Get started
-After installing MLflow Pipelines, you can clone this repository to get started.  
-Simply fill in the required values in the [Pipeline configuration file](https://github.com/mlflow/mlp-regression-template/blob/main/pipeline.yaml) 
+After installing MLflow Pipelines, you can clone this repository to get started. Simply fill in the required values in the [Pipeline configuration file](https://github.com/mlflow/mlp-regression-template/blob/main/pipeline.yaml) 
 and in the appropriate profile configuration: [`local.yaml`](https://github.com/mlflow/mlp-regression-template/blob/main/profiles/local.yaml) 
 (if running locally) or [`databricks.yaml`](https://github.com/mlflow/mlp-regression-template/blob/main/profiles/databricks.yaml) 
-(if running on Databricks).  
+(if running on Databricks).
+
 The Pipeline will then be in a runnable state, and when run completely, will produce a trained model ready for batch
 scoring, along with cards containing detailed information about the results of each step. 
 The model will also be registered to the MLflow Model Registry if it meets registration thresholds. 
@@ -64,6 +64,24 @@ The batch scoring workflow consists of the following sequential steps:
 ingest -> predict
 ```
 A detailed reference for each step follows.
+
+ * [Reference](#reference)
+    + [Step artifacts](#step-artifacts)
+    + [Ingest step](#ingest-step)
+      - [Data](#data)
+    + [Split step](#split-step)
+    + [Transform step](#transform-step)
+    + [Train step](#train-step)
+    + [Evaluate step](#evaluate-step)
+    + [Register step](#register-step)
+    + [MLflow Tracking / Model Registry configuration](#mlflow-tracking--model-registry-configuration)
+    + [Metrics](#metrics)
+      - [Built-in metrics](#built-in-metrics)
+      - [Custom metrics](#custom-metrics)
+  * [Scoring](#scoring)
+    + [Ingest step (scoring)](#ingest-step-scoring)
+    + [Predict step](#predict-step)
+
 ### Step artifacts
 Each of the steps in the pipeline produces artifacts after completion. These artifacts consist of cards containing
 detailed execution information, as well as other step-specific information.
@@ -90,7 +108,7 @@ It should return a Pandas DataFrame representing the content of the specified fi
 #### Data
 The input dataset is specified by the `data` section in [`pipeline.yaml`](https://github.com/mlflow/mlp-regression-template/blob/main/pipeline.yaml) as follows: 
 <details>
-<summary>Reference</summary>
+<summary>Full configuration reference</summary>
 
 - `location`: string. Required, unless `format` is `spark_sql`.  
 Dataset locations on the local filesystem are supported, as 
@@ -149,7 +167,7 @@ It should return a triple representing the processed train, validation and test 
 
 The split step is configured by the `steps.split` section in `pipeline.yaml` as follows:
 <details>
-<summary>Reference</summary>
+<summary>Full configuration reference</summary>
 
 - `split_ratios`: list. Optional.  
 A YAML list specifying the ratios by which to split the dataset into training, validation and test sets.  
@@ -157,13 +175,13 @@ A YAML list specifying the ratios by which to split the dataset into training, v
   ```
   split_ratios: [0.75, 0.125, 0.125] # Defaults to this ratio if unspecified
   ```
-- `post_split_method`: string. Optional.   
+- `post_split_filter_method`: string. Optional.   
 Fully qualified name of the method to use to "post-process" the split datasets. 
 This procedure is meant for removing/filtering records, or other cleaning processes. Arbitrary data transformations 
 should be done in the transform step.  
 <u>Example</u>:
   ```
-  post_split_method: steps.split.process_splits
+  post_split_filter_method: steps.split.process_splits
   ```
 </details>
 
@@ -184,7 +202,7 @@ and should return an unfitted estimator that is sklearn-compatible; that is, the
 
 The transform step is configured by the `steps.transform` section in pipeline.yaml:
 <details>
-<summary>Reference</summary>
+<summary>Full configuration reference</summary>
 
 - `transformer_method`: string. Optional.  
 Fully qualified name of the method that returns an `sklearn`-compatible transformer which applies feature 
@@ -218,7 +236,7 @@ and should return an unfitted estimator that is `sklearn`-compatible; that is, t
 
 The train step is configured by the `steps.train` section in pipeline.yaml:
 <details>
-<summary>Reference</summary>
+<summary>Full configuration reference</summary>
 
 - `estimator_method`: string. Required.  
 Fully qualified name of the method that returns an `sklearn`-compatible estimator used for model training.  
@@ -249,7 +267,7 @@ Model performance metrics and explanations are logged to the same MLflow Trackin
 
 The evaluate step is configured by the `steps.evaluate` section in pipeline.yaml:
 <details>
-<summary>Reference</summary>
+<summary>Full configuration reference</summary>
 
 - `validation_criteria`: list. Optional.  
 A list of validation thresholds, each of which a trained model must meet in order to be eligible for 
@@ -280,7 +298,7 @@ the model name and the model version.
 
 The register step is configured by the `steps.register` section in pipeline.yaml:
 <details>
-<summary>Reference</summary>
+<summary>Full configuration reference</summary>
 
 - `model_name`: string. Required.  
 Specifies the name to use when registering the trained model to the model registry.
@@ -306,7 +324,7 @@ Configuring a tracking server is optional. If this configuration is absent, the 
 
 Tracking information is configured with the `experiment` section in the profile configuration:
 <details>
-<summary>Reference</summary>
+<summary>Full configuration reference</summary>
 
 - `name`: string. Required, if configuring tracking.  
 Name of the experiment to log MLflow runs to.
@@ -325,7 +343,7 @@ To register trained models to the MLflow Model Registry, further configuration m
 
 To register models to a different server, specify the desired server in the `model_registry` section in the profile configuration:
 <details>
-<summary>Reference</summary>
+<summary>Full configuration reference</summary>
 
 - `uri`: string. Required, if this section is present.  
 URI of the model registry server to which to register trained models.
@@ -345,7 +363,7 @@ Models are ranked by this primary metric.
 
 Metrics are configured under the `metrics` section of pipeline.yaml, according to the following specification:
 <details>
-<summary>Reference</summary>
+<summary>Full configuration reference</summary>
 
 - `primary`: string. Required.  
 The name of the primary evaluation metric.
@@ -425,7 +443,7 @@ Once a scoring dataset is ingested, the `predict` step uses the model produced b
 against the scoring dataset.
 The predict step is configured by the `steps.predict` section in pipeline.yaml:
 <details>
-<summary>Reference</summary>
+<summary>Full configuration reference</summary>
 
 - `model_uri`: string. Optional.  
 Specifies the URI of the model to use in batch scoring. If empty, the latest model registered from the training step will be used.  


### PR DESCRIPTION
Signed-off-by: Apurva Koti <apurva.koti@databricks.com>

## What changes are proposed in this pull request?

Update the README to be a full reference for using the template to create a regression pipeline.

## How is this patch tested?

n/a

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Updated README to contain full template reference

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/regression`: Sklearn regression pipeline example
- [x] `area/build`: Build and test infrastructure for MLflow pipeline example

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
