### PR TITLE
add tuning params to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,46 +251,46 @@ Fully qualified name of the method that returns an `sklearn`-compatible estimato
   estimator_method: steps.train.estimator_fn
   ```
 
-<summary><strong><u>Tuning configuration reference</u></strong></summary>
+- Tuning configuration reference
 
-- `enabled`: boolean. Required.  
-Indicates whether or not tuning is enabled.
+   - `enabled`: boolean. Required.  
+   Indicates whether or not tuning is enabled.
 
-- `max_trials`: int. Required.  
-Max tuning trials to run.
+   - `max_trials`: int. Required.  
+   Max tuning trials to run.
 
-- `algorithm`: string. Optional.  
-Indicates whether or not tuning is enabled.
+   - `algorithm`: string. Optional.  
+   Indicates whether or not tuning is enabled.
 
-- `early_stop_fn`: string. Optional.  
-Early stopping function to be passed to hyperopt
+   - `early_stop_fn`: string. Optional.  
+   Early stopping function to be passed to hyperopt
 
-- `parallelism`: int. Optional.
-Number of workers to run hyperopt across.
+   - `parallelism`: int. Optional.
+   Number of workers to run hyperopt across.
 
-- `sample_fraction`: float. Optional.  
-Sampling fraction in the range (0, 1.0] to indicate the amount of data used in tuning.
+   - `sample_fraction`: float. Optional.  
+   Sampling fraction in the range (0, 1.0] to indicate the amount of data used in tuning.
 
-- `parameters`: list. Required.  
-Hyperopt search space in yaml format.
+   - `parameters`: list. Required.  
+   Hyperopt search space in yaml format.
 
-<u>Example</u>:
-  ```
-  tuning:
-  enabled: True
-  algorithm: "hyperopt.rand.suggest"
-  max_trials: 5
-  early_stop_fn: "hyperopt.early_stop.no_progress_loss(10)"
-  parallelism: 1
-  sample_fraction: 0.5
-  parameters:
-    alpha:
-      distribution: "uniform"
-      low: 0.0
-      high: 0.01
-    penalty:
-      values: ["l1", "l2", "elasticnet"]
-  ```
+   <u>Example</u>:
+   ```
+   tuning:
+   enabled: True
+   algorithm: "hyperopt.rand.suggest"
+   max_trials: 5
+   early_stop_fn: "hyperopt.early_stop.no_progress_loss(10)"
+   parallelism: 1
+   sample_fraction: 0.5
+   parameters:
+      alpha:
+         distribution: "uniform"
+         low: 0.0
+         high: 0.01
+      penalty:
+         values: ["l1", "l2", "elasticnet"]
+   ```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -263,16 +263,16 @@ Fully qualified name of the method that returns an `sklearn`-compatible estimato
    Indicates whether or not tuning is enabled.
 
    - `early_stop_fn`: string. Optional.  
-   Early stopping function to be passed to hyperopt
+   Early stopping function to be passed to `hyperopt`.
 
-   - `parallelism`: int. Optional.
-   Number of workers to run hyperopt across.
+   - `parallelism`: int. Optional.  
+   Number of workers to run `hyperopt` across.
 
    - `sample_fraction`: float. Optional.  
-   Sampling fraction in the range (0, 1.0] to indicate the amount of data used in tuning.
+   Sampling fraction in the range `(0, 1.0]` to indicate the amount of data used in tuning.
 
    - `parameters`: list. Required.  
-   Hyperopt search space in yaml format.
+   `hyperopt` search space in yaml format.
 
    <u>Example</u>:
    ```

--- a/README.md
+++ b/README.md
@@ -250,6 +250,48 @@ Fully qualified name of the method that returns an `sklearn`-compatible estimato
   ```
   estimator_method: steps.train.estimator_fn
   ```
+
+<summary><strong><u>Tuning configuration reference</u></strong></summary>
+
+- `enabled`: boolean. Required.  
+Indicates whether or not tuning is enabled.
+
+- `max_trials`: int. Required.  
+Max tuning trials to run.
+
+- `algorithm`: string. Optional.  
+Indicates whether or not tuning is enabled.
+
+- `early_stop_fn`: string. Optional.  
+Early stopping function to be passed to hyperopt
+
+- `parallelism`: int. Optional.
+Number of workers to run hyperopt across.
+
+- `sample_fraction`: float. Optional.  
+Sampling fraction in the range (0, 1.0] to indicate the amount of data used in tuning.
+
+- `parameters`: list. Required.  
+Hyperopt search space in yaml format.
+
+<u>Example</u>:
+  ```
+  tuning:
+  enabled: True
+  algorithm: "hyperopt.rand.suggest"
+  max_trials: 5
+  early_stop_fn: "hyperopt.early_stop.no_progress_loss(10)"
+  parallelism: 1
+  sample_fraction: 0.5
+  parameters:
+    alpha:
+      distribution: "uniform"
+      low: 0.0
+      high: 0.01
+    penalty:
+      values: ["l1", "l2", "elasticnet"]
+  ```
+
 </details>
 
 **Step artifacts**:


### PR DESCRIPTION
Signed-off-by: Prithvi Kannan <prithvi.kannan@databricks.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

We require adding a link to the [workflow](https://github.com/mlflow/mlflow/actions/workflows/pipeline-template.yml) for testing the [mlflow/mlp-regression-template](https://github.com/mlflow/mlp-regression-template) code path.

Run the workflow with repository name: `mlflow/mlp-regression-template` and the branch`(Example:<user-name>:feature)` that you are working with.
## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/regression`: Sklearn regression pipeline example
- [ ] `area/build`: Build and test infrastructure for MLflow pipeline example

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
