### PR TITLE
Fix `custom_metrics.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,7 +517,7 @@ A Pandas DataFrame containing two columns:
 - `builtin_metrics`: `Dict[str, int]`.  
 The built-in metrics calculated during model evaluation. Maps metric names to corresponding scalar values.
 
-The custom metric function should return a `Dict[str, int]`, mapping custom metric names to corresponding scalar metric values.
+The custom metric function should return a numeric scalar value.
 
 Custom metrics are specified as a list under the `metrics.custom` key in [`pipeline.yaml`](https://github.com/mlflow/mlp-regression-template/blob/main/pipeline.yaml), specified as follows:
 - `name`: string. Required.  

--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -108,6 +108,6 @@ metrics:
   #
   # custom:
   #   - name: ""
-  #     function: get_custom_metrics
+  #     function: get_custom_metric
   #     greater_is_better: False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-mlflow>=2.0
-pandas>=1.3.*
-scikit-learn>=1.1.*
-ipykernel>=6.12.*
-ipython>=7.32.*
-shap>=0.40.*
+mlflow>=2.0.0rc0
+pandas>=1.3
+scikit-learn>=1.1
+ipykernel>=6.12
+ipython>=7.32
+shap>=0.40

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mlflow[pipelines]>=1.27.0
+mlflow>=2.0
 pandas>=1.3.*
 scikit-learn>=1.1.*
 ipykernel>=6.12.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,3 @@
 mlflow>=2.0.0rc0
-pandas>=1.3
-scikit-learn>=1.1
 ipykernel>=6.12
 ipython>=7.32
-shap>=0.40

--- a/steps/custom_metrics.py
+++ b/steps/custom_metrics.py
@@ -31,7 +31,7 @@ def get_custom_metric(
                             metrics and the values are the scalar values of the metrics. For more
                             information, see
                             https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate.
-    :return: A scalar metric value.
+    :return: A numeric scalar value.
     """
     # FIXME::OPTIONAL: implement custom metric calculation here.
 

--- a/steps/custom_metrics.py
+++ b/steps/custom_metrics.py
@@ -19,8 +19,8 @@ from pandas import DataFrame
 
 def get_custom_metric(
     eval_df: DataFrame,
-    builtin_metrics: Dict[str, int],  # pylint: disable=unused-argument
-) -> Dict[str, int]:
+    builtin_metrics: Dict[str, float],  # pylint: disable=unused-argument
+) -> float:
     """
     FIXME::OPTIONAL: provide function doc string.
     :param eval_df: A Pandas DataFrame containing the following columns:

--- a/steps/custom_metrics.py
+++ b/steps/custom_metrics.py
@@ -17,7 +17,7 @@ from typing import Dict
 from pandas import DataFrame
 
 
-def get_custom_metrics(
+def get_custom_metric(
     eval_df: DataFrame,
     builtin_metrics: Dict[str, int],  # pylint: disable=unused-argument
 ) -> Dict[str, int]:
@@ -31,10 +31,8 @@ def get_custom_metrics(
                             metrics and the values are the scalar values of the metrics. For more
                             information, see
                             https://mlflow.org/docs/latest/python_api/mlflow.html#mlflow.evaluate.
-    :return: A single-entry dictionary containing the custom metrics. The key is the metric name
-             and the value is the scalar metric value. Note that custom metric functions can
-             return dictionaries with multiple metric entries as well.
+    :return: A scalar metric value.
     """
-    # FIXME::OPTIONAL: implement custom metrics calculation here.
+    # FIXME::OPTIONAL: implement custom metric calculation here.
 
     raise NotImplementedError


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Depends on https://github.com/mlflow/mlflow/pull/7142.
- Update the custom_metric template and document that it must return a numeric scalar value.

## How is this patch tested?

https://github.com/mlflow/mlflow/actions/runs/3366759905

We require adding a link to the [workflow](https://github.com/mlflow/mlflow/actions/workflows/pipeline-template.yml) for testing the [mlflow/mlp-regression-template](https://github.com/mlflow/mlp-regression-template) code path.

Run the workflow with repository name: `mlflow/mlp-regression-template` and the branch`(Example:<user-name>:feature)` that you are working with.
## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/regression`: Sklearn regression pipeline example
- [ ] `area/build`: Build and test infrastructure for MLflow pipeline example

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
